### PR TITLE
Fix login redirect

### DIFF
--- a/sections/shopify-login.liquid
+++ b/sections/shopify-login.liquid
@@ -33,10 +33,6 @@
       } else if (data.error_message) {
         document.getElementsByClassName("inventables__shopify-login__flash-message__text")[0].innerHTML = data.error_message;
       } 
-      var authenticated = ;
-      if (authenticated === 'true') {
-      } else {
-        
     }
   }, false);
 </script>

--- a/sections/shopify-login.liquid
+++ b/sections/shopify-login.liquid
@@ -28,7 +28,7 @@
   window.addEventListener("message", (event) => {
     if (event.origin === "{{ shop.metafields.development.local_address }}") {
       var data = JSON.parse(event.data);
-      if (data.authenticated == 'true') {
+      if (data.authenticated) {
         window.location.href = data.target_url;        
       } else if (data.error_message) {
         document.getElementsByClassName("inventables__shopify-login__flash-message__text")[0].innerHTML = data.error_message;

--- a/sections/shopify-login.liquid
+++ b/sections/shopify-login.liquid
@@ -30,13 +30,7 @@
       var data = JSON.parse(event.data);
       var authenticated = data.authenticated;
       if (authenticated === 'true') {
-        let searchParams = new URLSearchParams(window.location.search);
-        let checkoutUrl = searchParams.get('checkout_url');
-        if (checkoutUrl) {
-          window.location.href = checkoutUrl;
-        } else {
-          window.location.href = event.origin + "/checkout";
-        }
+        window.location.href = data.target_url;
       } else {
         document.getElementsByClassName("inventables__shopify-login__flash-message__text")[0].innerHTML = 'Incorrect email or password. Please try again.';
       }

--- a/sections/shopify-login.liquid
+++ b/sections/shopify-login.liquid
@@ -28,12 +28,13 @@
   window.addEventListener("message", (event) => {
     if (event.origin === "{{ shop.metafields.development.local_address }}") {
       var data = JSON.parse(event.data);
-      if (data.error_message) {
+      if (data.authenticated == 'true') {
+        window.location.href = data.target_url;        
+      } else if (data.error_message) {
         document.getElementsByClassName("inventables__shopify-login__flash-message__text")[0].innerHTML = data.error_message;
-      }
-      var authenticated = data.authenticated;
+      } 
+      var authenticated = ;
       if (authenticated === 'true') {
-        window.location.href = data.target_url;
       } else {
         
     }

--- a/sections/shopify-login.liquid
+++ b/sections/shopify-login.liquid
@@ -9,29 +9,40 @@
   <div id="login" class="inventables__shopify-login">
     <iframe id="logout" scrolling="no" src="{{ shop.metafields.development.local_address }}/logout" style="border: none; height: 0px; width: 0px;">
     </iframe>
-    <iframe id="inventables" scrolling="no" src="{{ shop.metafields.development.local_address }}/shopify/login_form" style="border: none;">
-    </iframe>
-    <script type="text/javascript">
-      window.addEventListener("message", (event) => {
-          if (event.origin === "{{ shop.metafields.development.local_address }}") {
-              var data = JSON.parse(event.data);
-              var authenticated = data.authenticated;
-              if (authenticated === 'true') {
-                let searchParams = new URLSearchParams(window.location.search);
-                let checkoutUrl = searchParams.get('checkout_url');
-                if (checkoutUrl) {
-                  window.location.href = checkoutUrl;
-                } else {
-                  window.location.href = event.origin + "/checkout";
-                }
-              } else {
-                    document.getElementsByClassName("inventables__shopify-login__flash-message__text")[0].innerHTML = 'Incorrect email or password. Please try again.';
-              }
-          }
-      }, false);
-    </script>
   </div>
 </div>
+<script type="text/javascript">
+  window.onload = function() {
+    let loginDiv = document.getElementById("login");
+    let loginForm = document.createElement("iframe");
+    loginForm.scrolling = "no";
+    loginForm.style = "border: none;";
+    loginForm.id="inventables";
+
+    let searchParams = new URLSearchParams(window.location.search);
+    let iframeSource = "{{ shop.metafields.development.local_address }}/shopify/login_form?" + searchParams.toString();
+    loginForm.setAttribute("src", iframeSource);
+    loginDiv.appendChild(loginForm);
+  }
+
+  window.addEventListener("message", (event) => {
+    if (event.origin === "{{ shop.metafields.development.local_address }}") {
+      var data = JSON.parse(event.data);
+      var authenticated = data.authenticated;
+      if (authenticated === 'true') {
+        let searchParams = new URLSearchParams(window.location.search);
+        let checkoutUrl = searchParams.get('checkout_url');
+        if (checkoutUrl) {
+          window.location.href = checkoutUrl;
+        } else {
+          window.location.href = event.origin + "/checkout";
+        }
+      } else {
+        document.getElementsByClassName("inventables__shopify-login__flash-message__text")[0].innerHTML = 'Incorrect email or password. Please try again.';
+      }
+    }
+  }, false);
+</script>
 
 {%- style -%}
   .section-{{ section.id }}-padding {

--- a/sections/shopify-login.liquid
+++ b/sections/shopify-login.liquid
@@ -28,12 +28,14 @@
   window.addEventListener("message", (event) => {
     if (event.origin === "{{ shop.metafields.development.local_address }}") {
       var data = JSON.parse(event.data);
+      if (data.error_message) {
+        document.getElementsByClassName("inventables__shopify-login__flash-message__text")[0].innerHTML = data.error_message;
+      }
       var authenticated = data.authenticated;
       if (authenticated === 'true') {
         window.location.href = data.target_url;
       } else {
-        document.getElementsByClassName("inventables__shopify-login__flash-message__text")[0].innerHTML = 'Incorrect email or password. Please try again.';
-      }
+        
     }
   }, false);
 </script>

--- a/sections/shopify-login.liquid
+++ b/sections/shopify-login.liquid
@@ -17,7 +17,13 @@
               var data = JSON.parse(event.data);
               var authenticated = data.authenticated;
               if (authenticated === 'true') {
+                let searchParams = new URLSearchParams(window.location.search);
+                let checkoutUrl = searchParams.get('checkout_url');
+                if (checkoutUrl) {
+                  window.location.href = checkoutUrl;
+                } else {
                   window.location.href = event.origin + "/checkout";
+                }
               } else {
                     document.getElementsByClassName("inventables__shopify-login__flash-message__text")[0].innerHTML = 'Incorrect email or password. Please try again.';
               }


### PR DESCRIPTION
Change the redirect destination after logging in to whatever we get from FBolt. 
This is expected to be a multipass url with a `return_to` set. This allows us to direct the user to a destination on Shopify while also logging them in. 