### PR TITLE
Install Google Tag Manager snippets

### DIFF
--- a/layout/checkout.liquid
+++ b/layout/checkout.liquid
@@ -1,6 +1,14 @@
 <!DOCTYPE html>
 <html lang="{{ locale }}" dir="{{ direction }}" class="{{ checkout_html_classes }}">
   <head>
+    <!-- Google Tag Manager -->
+    <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
+    new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
+    j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
+    'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
+    })(window,document,'script','dataLayer','GTM-5H85H3N');</script>
+    <!-- End Google Tag Manager -->
+
     <meta charset="utf-8">
     <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1">
     <meta name="viewport" content="width=device-width, initial-scale=1.0, height=device-height, minimum-scale=1.0, user-scalable=0">
@@ -14,6 +22,11 @@
     {{ checkout_scripts }}
   </head>
   <body>
+    <!-- Google Tag Manager (noscript) -->
+    <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-5H85H3N"
+    height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
+    <!-- End Google Tag Manager (noscript) -->
+
     {{ skip_to_content_link }}
 
     <header class="banner" data-header role="banner">

--- a/layout/theme.liquid
+++ b/layout/theme.liquid
@@ -2,7 +2,7 @@
 <html class="no-js" lang="{{ request.locale.iso_code }}">
   <head>
     {% capture CFH %}{{ content_for_header  }}{% endcapture %}
-  
+
     {% if CFH contains 'admin_bar_iframe' %}
       {% assign admin = true %}
     {% elsif CFH contains 'preview_bar_injector-' %}
@@ -16,6 +16,15 @@
     {% unless admin %}
       <script>window.location.href = 'https://inventables.com'</script>
     {% endunless %}
+
+    <!-- Google Tag Manager -->
+    <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
+    new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
+    j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
+    'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
+    })(window,document,'script','dataLayer','GTM-5H85H3N');</script>
+    <!-- End Google Tag Manager -->
+
     <meta charset="utf-8">
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <meta name="viewport" content="width=device-width,initial-scale=1">
@@ -257,6 +266,11 @@
   </head>
 
   <body class="gradient">
+    <!-- Google Tag Manager (noscript) -->
+    <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-5H85H3N"
+    height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
+    <!-- End Google Tag Manager (noscript) -->
+
     <a class="skip-to-content-link button visually-hidden" href="#MainContent">
       {{ "accessibility.skip_to_text" | t }}
     </a>


### PR DESCRIPTION
### PR Summary: 

Installs the JS snippets for our Google Tag Manager container. 

### Why are these changes introduced?

This should restore firing of some tags that were disrupted when we migrated to Shopify's checkout.

### What approach did you take?

I followed steps 1-6 in this [Shopify help article](https://help.shopify.com/en/manual/reports-and-analytics/google-analytics/google-tag-manager#add-google-tag-manager-code-to-your-theme).


### After deploy

After deploying, we will need to reconfigure the `XCP-Adwords_Purchase` tag in TagManager. Specifically, we will need to create or refactor the `XCP-orderSubmit` Trigger for this tag:

<img width="582" alt="image" src="https://user-images.githubusercontent.com/26750330/217110647-a1a9f5aa-9c9c-4ec4-9402-850013445d46.png">

<img width="536" alt="image" src="https://user-images.githubusercontent.com/26750330/217110673-8339831a-1a6e-4e39-8409-8811c1685a5d.png">


