### PR TITLE
Install environment-dependent Google Tag Manager snippets

### DIFF
--- a/layout/checkout.liquid
+++ b/layout/checkout.liquid
@@ -56,6 +56,7 @@
             {{ alternative_payment_methods }}
           </header>
           <main class="main__content" role="main">
+            <h1>Is this thing on?</h1>
             {{ content_for_layout }}
           </main>
           <footer class="main__footer" role="contentinfo">

--- a/layout/checkout.liquid
+++ b/layout/checkout.liquid
@@ -46,6 +46,7 @@
     <header class="banner" data-header role="banner">
       <div class="wrap">
         <a class="logo" href="https://inventables.com/">{{ 'rebranded-inv-logo.png' | asset_url | img_tag: 'Logo' }}</a>
+        <h1>Cool logo!</h1>
       </div>
     </header>
 

--- a/layout/checkout.liquid
+++ b/layout/checkout.liquid
@@ -44,10 +44,6 @@
     {{ skip_to_content_link }}
 
     <header class="banner" data-header role="banner">
-      <div class="wrap">
-        <a class="logo" href="https://inventables.com/">{{ 'rebranded-inv-logo.png' | asset_url | img_tag: 'Logo' }}</a>
-        <h1>Cool logo!</h1>
-      </div>
     </header>
 
     {{ order_summary_toggle }}

--- a/layout/checkout.liquid
+++ b/layout/checkout.liquid
@@ -1,13 +1,25 @@
 <!DOCTYPE html>
 <html lang="{{ locale }}" dir="{{ direction }}" class="{{ checkout_html_classes }}">
   <head>
-    <!-- Google Tag Manager -->
-    <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
-    new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
-    j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
-    'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
-    })(window,document,'script','dataLayer','GTM-5H85H3N');</script>
-    <!-- End Google Tag Manager -->
+    {%- assign production_shop_id = '60429828153' -%}
+    {%- assign staging_shop_id    = '67711828243' -%}
+
+    {%- case shop.id -%}
+    {%- when production_shop_id -%}
+      {%- assign google_tag_manager_container_id = 'GTM-5H85H3N' -%}
+    {%- when staging_shop_id -%}
+      {%- assign google_tag_manager_container_id = 'GTM-TG2KSNK' -%}
+    {%- endcase %}
+
+    {%- unless google_tag_manager_container_id == blank -%}
+      <!-- Google Tag Manager -->
+      <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
+      new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
+      j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
+      'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
+      })(window,document,'script','dataLayer','{{ google_tag_manager_container_id }}');</script>
+      <!-- End Google Tag Manager -->
+    {%- endunless -%}
 
     <meta charset="utf-8">
     <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1">
@@ -22,10 +34,12 @@
     {{ checkout_scripts }}
   </head>
   <body>
-    <!-- Google Tag Manager (noscript) -->
-    <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-5H85H3N"
-    height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
-    <!-- End Google Tag Manager (noscript) -->
+    {%- unless google_tag_manager_container_id == blank -%}
+      <!-- Google Tag Manager (noscript) -->
+      <noscript><iframe src="https://www.googletagmanager.com/ns.html?id={{ google_tag_manager_container_id }}"
+      height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
+      <!-- End Google Tag Manager (noscript) -->
+    {%- endunless -%}
 
     {{ skip_to_content_link }}
 

--- a/layout/checkout.liquid
+++ b/layout/checkout.liquid
@@ -1,8 +1,8 @@
 <!DOCTYPE html>
 <html lang="{{ locale }}" dir="{{ direction }}" class="{{ checkout_html_classes }}">
   <head>
-    {%- assign production_shop_id = '60429828153' -%}
-    {%- assign staging_shop_id    = '67711828243' -%}
+    {%- assign production_shop_id = 60429828153 -%}
+    {%- assign staging_shop_id    = 67711828243 -%}
 
     {%- case shop.id -%}
     {%- when production_shop_id -%}

--- a/layout/theme.liquid
+++ b/layout/theme.liquid
@@ -17,8 +17,8 @@
       <script>window.location.href = 'https://inventables.com'</script>
     {% endunless %}
 
-    {%- assign production_shop_id = '60429828153' -%}
-    {%- assign staging_shop_id    = '67711828243' -%}
+    {%- assign production_shop_id = 60429828153 -%}
+    {%- assign staging_shop_id    = 67711828243 -%}
 
     {%- case shop.id -%}
     {%- when production_shop_id -%}

--- a/layout/theme.liquid
+++ b/layout/theme.liquid
@@ -17,13 +17,25 @@
       <script>window.location.href = 'https://inventables.com'</script>
     {% endunless %}
 
-    <!-- Google Tag Manager -->
-    <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
-    new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
-    j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
-    'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
-    })(window,document,'script','dataLayer','GTM-5H85H3N');</script>
-    <!-- End Google Tag Manager -->
+    {%- assign production_shop_id = '60429828153' -%}
+    {%- assign staging_shop_id    = '67711828243' -%}
+
+    {%- case shop.id -%}
+    {%- when production_shop_id -%}
+      {%- assign google_tag_manager_container_id = 'GTM-5H85H3N' -%}
+    {%- when staging_shop_id -%}
+      {%- assign google_tag_manager_container_id = 'GTM-TG2KSNK' -%}
+    {%- endcase %}
+
+    {%- unless google_tag_manager_container_id == blank -%}
+      <!-- Google Tag Manager -->
+      <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
+      new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
+      j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
+      'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
+      })(window,document,'script','dataLayer','{{ google_tag_manager_container_id }}');</script>
+      <!-- End Google Tag Manager -->
+    {%- endunless -%}
 
     <meta charset="utf-8">
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
@@ -266,10 +278,12 @@
   </head>
 
   <body class="gradient">
-    <!-- Google Tag Manager (noscript) -->
-    <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-5H85H3N"
-    height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
-    <!-- End Google Tag Manager (noscript) -->
+    {%- unless google_tag_manager_container_id == blank -%}
+      <!-- Google Tag Manager (noscript) -->
+      <noscript><iframe src="https://www.googletagmanager.com/ns.html?id={{ google_tag_manager_container_id }}"
+      height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
+      <!-- End Google Tag Manager (noscript) -->
+    {%- endunless -%}
 
     <a class="skip-to-content-link button visually-hidden" href="#MainContent">
       {{ "accessibility.skip_to_text" | t }}


### PR DESCRIPTION
* Only render Google Tag Manager snippet in production or staging
* Toggle the correct GTM Container ID

### PR Summary: 

Updates `theme.liquid` and `checkout.liquid` to render the correct GTM snippet depending on the environment.

Without this, Staging (and possibly Development, and even the Shopify Theme Editor previews) could send data to Google Tag Manager. This is probably not consequential but we don't want to muddy the waters if we can avoid it.

### Related to https://github.com/inventables/fbolt/issues/5860