### PR TITLE
Add distinct skus to dataLayer ecommerce objects

### DIFF
--- a/layout/checkout.liquid
+++ b/layout/checkout.liquid
@@ -92,20 +92,23 @@
             - [ ] X-Carves (and possibly other products) are represented differently:
                   X-Carves are now a single item with sku 30686-07(M|D), whereas before
                   Shopify we listed all the items that make up an X-Carve
+            - [ ] Check what happens in skus_comma_separated when a line_item has no SKU
           {% endcomment %}
 
+          {%- assign skus_comma_separated = checkout.line_items | map: "sku" | uniq | sort | join: "," -%}
+
           if (Shopify.Checkout.step === "contact_information") {
-            {% render "google-data-layer-ecommerce-begin-checkout" %}
+            {% render "google-data-layer-ecommerce-begin-checkout", skus: skus_comma_separated %}
           }
 
           if (Shopify.Checkout.step === "payment_method") {
             {% if checkout.requires_shipping %}
-              {% render "google-data-layer-ecommerce-add-shipping-info" %}
+              {% render "google-data-layer-ecommerce-add-shipping-info", skus: skus_comma_separated %}
             {% endif %}
           }
 
           if (Shopify.Checkout.page === "thank_you") {
-            {% render "google-data-layer-ecommerce-purchase" %}
+            {% render "google-data-layer-ecommerce-purchase", skus: skus_comma_separated %}
           }
         });
       })(Checkout.$);

--- a/snippets/google-data-layer-ecommerce-add-shipping-info.liquid
+++ b/snippets/google-data-layer-ecommerce-add-shipping-info.liquid
@@ -15,6 +15,7 @@ dataLayer.push({
       {% endfor %}
     ],
     shipping_tier: "{{ checkout.shipping_method.title }}",
+    skus: "{{ skus }}".split(","),
     value: {{ checkout.total_price | money_without_currency | remove: "," }}
   }
 });

--- a/snippets/google-data-layer-ecommerce-begin-checkout.liquid
+++ b/snippets/google-data-layer-ecommerce-begin-checkout.liquid
@@ -14,6 +14,7 @@ dataLayer.push({
         },
       {% endfor %}
     ],
+    skus: "{{ skus }}".split(","),
     value: {{ checkout.total_price | money_without_currency | remove: "," }},
   }
 });

--- a/snippets/google-data-layer-ecommerce-purchase.liquid
+++ b/snippets/google-data-layer-ecommerce-purchase.liquid
@@ -15,6 +15,7 @@ dataLayer.push({
       {% endfor %}
     ],
     shipping: {{ checkout.shipping_price | money_without_currency | remove: "," }},
+    skus: "{{ skus }}".split(","),
     tax: {{ checkout.tax_price | money_without_currency | remove: "," }},
     transaction_id: "{{ checkout.order_id }}",
     value: {{ checkout.total_price | money_without_currency | remove: "," }},


### PR DESCRIPTION
### PR Summary: 

Adds a `skus` property to the ecommerce objects pushed to the dataLayer

(Technically, this is only used when the `purchase` event occurs, but it could be useful for other events in the checkout flow.)

### Why are these changes introduced?

This is needed to enable conversion tracking in Google Ads via Google Tag Manager.

By adding `skus`, we can access them in Google Tag Manager:

<img width="279" alt="image" src="https://user-images.githubusercontent.com/26750330/222000199-dbf92d46-6735-40e4-ac53-258d76aac860.png">

We can then create a GTM Trigger to check for the presence of a specific SKU. For example, this Trigger can be used to fire a Tag when a customer is checking out with an X-Carve Pro:

<img width="491" alt="image" src="https://user-images.githubusercontent.com/26750330/222000315-4ec9d20c-b555-468d-90d8-b85db4eea977.png">

With this Trigger, we can create the appropriate Google Ads Conversion Tracking Tag so that we can track XCP conversions in Google Ads and measure the performance of our ad campaigns.

### What approach did you take?

Apparently it's not possible to directly assign an array to a liquid variable, so I map over `checkout.line_items` to concatenate the SKUs into a comma-separated string. I pass that variable into each snippet, and from there we use `String.prototype.split` to cast it to an Array of strings.

<img width="314" alt="image" src="https://user-images.githubusercontent.com/26750330/222000954-b830e26a-936a-4ffa-852c-7229bd5ecc10.png">

### Related Issues

Once the GTM Tag is configured and our Google consultants confirm tracking is restored, we can close https://github.com/inventables/fbolt/issues/5860