### PR TITLE
Hide Shop Pay banner from all product pages

### DIFF
--- a/sections/featured-product.liquid
+++ b/sections/featured-product.liquid
@@ -130,7 +130,10 @@
                   <div {{ block.shopify_attributes }}>
                     {%- form 'product', product -%}
                       <input type="hidden" name="id" value="{{ product.selected_or_first_available_variant.id }}">
+                      {% comment%}
+                      hide "From $X/mo with Shop Pay" banner
                       {{ form | payment_terms }}
+                      {% endcomment %}
                     {%- endform -%}
                   </div>
                 {%- endif -%}

--- a/sections/main-product.liquid
+++ b/sections/main-product.liquid
@@ -339,7 +339,10 @@
                 {%- assign product_form_installment_id = 'product-form-installment-' | append: section.id -%}
                 {%- form 'product', product, id: product_form_installment_id, class: 'installment caption-large' -%}
                   <input type="hidden" name="id" value="{{ product.selected_or_first_available_variant.id }}">
+                  {% comment%}
+                  hide "From $X/mo with Shop Pay" banner
                   {{ form | payment_terms }}
+                  {% endcomment %}
                 {%- endform -%}
               </div>
             {%- when 'description' -%}
@@ -535,7 +538,7 @@
                   </variant-selects>
                 {%- endif -%}
               {%- endunless -%}
-              
+
 
               <noscript class="product-form__noscript-wrapper-{{ section.id }}">
                 <div class="product-form__input{% if product.has_only_default_variant %} hidden{% endif %}">


### PR DESCRIPTION
This Liquid is responsible for rendering the "From $X/mo with Shop Pay" banner that appears on product pages.

```
{{ form | payment_terms }}
```

This is not accessible in the Theme Editor, so in order to change it we need to modify this theme code.

See: https://help.shopify.com/en/manual/payments/shop-pay-installments/product-banner