### PR TITLE
X-Carve Pro product page adjustments

### DIFF
--- a/templates/product.x-carve-pro-product-page.json
+++ b/templates/product.x-carve-pro-product-page.json
@@ -49,12 +49,6 @@
           "settings": {
           }
         },
-        "52e2cff8-9aa7-40d7-a6e8-dc4fc28f9a21": {
-          "type": "custom_liquid",
-          "settings": {
-            "custom_liquid": "<input type=\"checkbox\">\n\nAdd 3-year protection plan for $500 (US customers only). <a href=\"https:\/\/www.inventables.com\">See plan details<\/a>."
-          }
-        },
         "buy_buttons": {
           "type": "buy_buttons",
           "settings": {
@@ -105,7 +99,6 @@
         "description",
         "variant_picker",
         "quantity_selector",
-        "52e2cff8-9aa7-40d7-a6e8-dc4fc28f9a21",
         "buy_buttons",
         "c4f25434-e1c1-4018-a79e-fb29029190e6",
         "2a1a9511-b894-4fe1-b0f2-b1bdb879f91a",
@@ -195,7 +188,7 @@
       ],
       "custom_css": [
         "a {color: #ffb762; font-weight: bold; text-decoration: none;}",
-        ".multicolumn {border-radius: 20px;}",
+        ".multicolumn {border-radius: 20px; margin: 0 10%;}",
         ".multicolumn.background-primary .multicolumn-card {background: none;}"
       ],
       "settings": {
@@ -286,7 +279,8 @@
         "template--18332860875027__ea78870a-ef93-4d24-aa5b-5673d55b0666-16795206207e4657e7-0"
       ],
       "custom_css": [
-        "h2 {font-size: 64px; border-bottom: 3px solid #ffb256;}",
+        ".rich-text {margin: 0 10%;}",
+        "h2 {font-size: 32px; border-bottom: 3px solid #ffb256;}",
         "h2.rich-text__heading {border: none;}"
       ],
       "settings": {
@@ -325,7 +319,10 @@
         "template--18332860875027__d222d3fb-a385-44a7-b7e2-db0514072cf6-16795190868ec24049-2"
       ],
       "custom_css": [
-        "h2 {text-align: center; text-decoration: underline;}"
+        "h2 {text-align: center; text-decoration: underline;}",
+        ".multicolumn {margin: 0 10%;}",
+        ".multicolumn-list {justify-content: center;}",
+        ".multicolumn-list__item {max-width: 350px;}"
       ],
       "settings": {
         "title": "",


### PR DESCRIPTION
Minor adjustments to the X-Carve Pro product page:

* Remove Clyde protection plan checkbox placeholder
* Adjust margins of 'You will need...'
* Adjust margins and flex spacing of 'Details'


**Screenshots**
<img width="1216" alt="image" src="https://github.com/inventables/ecomm-theme-dawn/assets/26750330/99e03d81-848d-49d8-b755-0d8e49c7dd5e">

<img width="1903" alt="SCR-20230515-nvln" src="https://github.com/inventables/ecomm-theme-dawn/assets/26750330/8ab307d6-739a-4527-8d1d-6b6f68950a99">
<img width="1914" alt="SCR-20230515-nvmp" src="https://github.com/inventables/ecomm-theme-dawn/assets/26750330/90342018-b5da-4ca3-8225-523cebba7740">

**Full page screenshot for reference**
![SCR-20230515-nvje](https://github.com/inventables/ecomm-theme-dawn/assets/26750330/5f21677e-3513-45c9-bb4f-8b6812240974)
