### PR TITLE
Further improvements to X-Carve Pro 4x4 product page template

### DIFF
--- a/templates/product.x-carve-pro-product-page.json
+++ b/templates/product.x-carve-pro-product-page.json
@@ -28,7 +28,7 @@
         "6a3d3945-578d-402b-9da6-d86bbc87438a": {
           "type": "custom_liquid",
           "settings": {
-            "custom_liquid": "{% style %}\n\n@media only screen and (max-width: 960px) {\n    .affirm-as-low-as {\n        margin-top:-4px\n    }\n}\n\n.affirm-as-low-as .affirm-modal-trigger {\n    color: #eee;\n    text-decoration: underline\n}\n\n\n{% endstyle %}\n\n<div class=\"affirm-as-low-as\" data-learnmore-show=\"true\" data-page-type=\"product\" data-affirm-color=\"white\" data-amount=\"{{ product.selected_or_first_available_variant.price  }}\">Or for a low monthly price with Affirm.<\/div>\n\n                <div class=\"kit-select__affirm-explanation-message\">\n                  Financing payments begin <b> after <\/b> the unit ships\n                <\/div>"
+            "custom_liquid": "{% style %}\n\n@media only screen and (max-width: 960px) {\n    .affirm-as-low-as {\n        margin-top:-4px\n    }\n}\n\n.affirm-as-low-as .affirm-modal-trigger {\n    color: #eee;\n    text-decoration: underline\n}\n\n\n{% endstyle %}\n\n<div class=\"affirm-as-low-as\" data-learnmore-show=\"true\" data-page-type=\"product\" data-affirm-color=\"white\" data-amount=\"{{ product.selected_or_first_available_variant.price  }}\">Or for a low monthly price with Affirm.<\/div>\n\n                <div class=\"kit-select__affirm-explanation-message\">\n                  Financing payments begin after the unit ships.\n                <\/div>"
           }
         },
         "description": {
@@ -49,6 +49,12 @@
           "settings": {
           }
         },
+        "3297560c-720c-492c-89aa-aa7a416d7036": {
+          "type": "custom_liquid",
+          "settings": {
+            "custom_liquid": "{% style %}\n.xcp-size-select {\n  display: flex;\n  align-items: center;\n  width: 200px;\n}\n.xcp-size-select .xcp__size-word {\n  margin-right: 10px;\n}\n.xcp-size-select .xcp-size-select__btn {\n  color: var(--gradient-base-background-1);\n  font-weight: normal;\n  text-transform: none;\n  padding: 4px 20px;\n  margin: 0 8px;\n  height: 36px;\n  display: inline-flex;\n  align-items: center;\n}\n.xcp-size-select .xcp-size-select__btn:hover {\n  text-decoration: none;\n  color: var(--gradient-base-background-1);\n}\n.xcp-size-select .xcp-size-select__btn--4x2 {\n  color: #eee;\n  background-color: var(--gradient-base-background-1);\n  border: 2px solid #eee;\n  font-weight: normal;\n  text-transform: none;\n  padding: 4px 20px;\n  margin: 0 8px;\n}\n.xcp-size-select .xcp-size-select__btn--4x2:hover {\n  background-color: #ffb256;\n  border: 2px solid #ffb256;\n}\n{% endstyle %}\n\n<div class=\"xcp-size-select\">\n  <span class=\"xcp__size-word\">Size<\/span>\n  <button class=\"btn btn-primary xcp-size-select__btn\">4x4<\/button>\n  {% comment %}\n    link to 4x2 XCP product page\n  {% endcomment %}\n  <a class=\"btn btn-primary xcp-size-select__btn xcp-size-select__btn--4x2\" href=\"#\">4x2<\/a>\n<\/div>"
+          }
+        },
         "buy_buttons": {
           "type": "buy_buttons",
           "settings": {
@@ -58,7 +64,7 @@
         "c4f25434-e1c1-4018-a79e-fb29029190e6": {
           "type": "custom_liquid",
           "settings": {
-            "custom_liquid": "For Business Financing Options <a href=\"https:\/\/www.clicklease.com\/partner\/inventables\/\">Apply Here<\/a>"
+            "custom_liquid": "{% style %}\n.product a {\n  color: #eee;\n  font-weight: bold;\n}\n.product a:hover {\n  color: #ffb256;\n  text-decoration: underline;\n}\n{% endstyle %}\n\nFor Business Financing <a href=\"https:\/\/www.clicklease.com\/partner\/inventables\/\">Click Here<\/a>"
           }
         },
         "2a1a9511-b894-4fe1-b0f2-b1bdb879f91a": {
@@ -99,6 +105,7 @@
         "description",
         "variant_picker",
         "quantity_selector",
+        "3297560c-720c-492c-89aa-aa7a416d7036",
         "buy_buttons",
         "c4f25434-e1c1-4018-a79e-fb29029190e6",
         "2a1a9511-b894-4fe1-b0f2-b1bdb879f91a",
@@ -107,7 +114,12 @@
         "0a827ec2-09ca-4fb7-8002-58defadd7e3f"
       ],
       "custom_css": [
-        ".product--large {max-width: 1000px; margin: 0 auto;}"
+        ".product--large {max-width: 1200px; margin: 0 auto;}",
+        ".product__media-wrapper {max-width: 50%;}",
+        ".product__info-wrapper {max-width: 50%;}",
+        "product-form {max-width: 200px; background-color: var(--gradient-base-background-1);}",
+        "product-form button {color: var(--gradient-base-background-1); font-weight: bold; background-color: #ffb256; text-transform: uppercase; --border-opacity: none;}",
+        "product-form button:hover {background-color: #ffe3a6;}"
       ],
       "settings": {
         "enable_sticky_info": true,


### PR DESCRIPTION
* Split product media and product info sections 50/50 within the container.
* Add size "buttons"
  * 4x4 button won't do anything
  * 4x2 is an `<a></a>` that will link to the not-yet-imported 4x2 product


<img width="1131" alt="image" src="https://github.com/Shopify/dawn/assets/26750330/8518e264-be6b-4c29-b7e2-9ea92a9d6147">
