### PR TITLE
Override CSS width to fix bug with images on collection pages

### DIFF
--- a/templates/collection.json
+++ b/templates/collection.json
@@ -10,6 +10,9 @@
     },
     "product-grid": {
       "type": "main-collection-product-grid",
+      "custom_css": [
+        ".card .card__inner .card__media {width: 100%;}"
+      ],
       "settings": {
         "products_per_page": 16,
         "columns_desktop": 4,
@@ -17,7 +20,9 @@
         "show_secondary_image": false,
         "show_vendor": false,
         "show_rating": false,
+        "enable_quick_add": false,
         "enable_filtering": true,
+        "filter_type": "horizontal",
         "enable_sorting": true,
         "columns_mobile": "2",
         "padding_top": 36,


### PR DESCRIPTION
There seems to be an issue with our current version of the Dawn theme (or how we're using it).

I'm not certain if this is the culprit, but the CSS `calc` function for the .card__media width is resulting in `0`, when I expect it to be `100%`:

<img width="629" alt="image" src="https://github.com/inventables/ecomm-theme-dawn/assets/26750330/0a3cc8c8-e7ac-4720-bd15-ccc957f78001">

Even when I set the custom CSS to the exact same value using `calc`, the result is 100%. This makes me think something else is messing with the width.

```
calc(100% - 2 * var(--image-padding))

var(--image-padding) is 0.0 rem, so 100% - 2 * 0 should equal 100%
```

I explicitly set the width to 100% in the Custom CSS section of the collections template.

Specifically, go to Collections > Default Collection > Product Grid

On the right sidebar scroll to the bottom.


https://github.com/inventables/ecomm-theme-dawn/assets/26750330/b54496fb-5c6f-4a53-bb3b-b17e5b8adf7a

