### PR TITLE
Hide variants

### DIFF
--- a/assets/global.js
+++ b/assets/global.js
@@ -850,7 +850,7 @@ class VariantSelects extends HTMLElement {
         const price = document.getElementById(`price-${this.dataset.section}`);
 
         if (price) price.classList.remove('visibility-hidden');
-        this.toggleAddButton(!this.currentVariant.available, window.variantStrings.soldOut);
+        this.toggleAddButton(!this.currentVariant.available, window.variantStrings.unavailable);
       });
   }
 

--- a/assets/inventables.js
+++ b/assets/inventables.js
@@ -32,15 +32,27 @@ document.addEventListener('DOMContentLoaded', () => {
   const optionGroups = fieldsets.map((fs) => { return Array.from(fs.querySelectorAll('input'))  });
   const labelGroups = fieldsets.map((fs) => { return Array.from(fs.querySelectorAll('label'))  });
   optionGroups.forEach((og, i) => {
-    const labelGroup = labelGroups[i];
-    let availableVariants = og.map((option, j) => {
+    const availableOptions = [];
+    let needsReset = false;
+
+    og.forEach((option, j) => {
       let availableVariant = variantData.find((variant) => {
         return variant.options[i] === option.value && variant.available  });
       if (!availableVariant) {
+        if (option.checked) {
+          needsReset = true;
+        }
+
         option.style.display = 'none';
         labelGroups[i][j].style.display = 'none';
+      } else {
+        availableOptions.push(option);
       }
     });
+
+    if (needsReset && availableOptions.length > 0) {
+      availableOptions[0].checked = true;
+    }
   });
 
   variantRadios.onVariantChange();

--- a/assets/inventables.js
+++ b/assets/inventables.js
@@ -4,17 +4,14 @@ class VariantMetafields extends HTMLElement {
   }
 
   getMetafields() {
-    this.metafields = this.metafields || this.querySelector('[type="application/json"]').textContent;
+    this.metafields = this.metafields || JSON.parse(this.querySelector('[type="application/json"]').textContent);
     return this.metafields;
   }
 }
 
 customElements.define('variant-metafields', VariantMetafields);
 
-function suppressInvalidOptions() {
-  let metaFields = JSON.parse(document.querySelectorAll('variant-metafields')[0].getMetafields());
-  let variantSelect = document.querySelectorAll('variant-selects, variant-radios')[0]
-  let variantData = variantSelect.getVariantData();
+function suppressInvalidOptions(metaFields, variantData) {
   variantData.forEach((variant) => {
     let metaField = metaFields[variant.id];
     if (metaField) {
@@ -23,8 +20,28 @@ function suppressInvalidOptions() {
   });
 }
 
+
+
 document.addEventListener('DOMContentLoaded', () => {
-  suppressInvalidOptions();
-  let variantSelect = document.querySelectorAll('variant-selects, variant-radios')[0];
-  variantSelect.onVariantChange();
+  let variantRadios = document.querySelectorAll('variant-radios')[0];
+  let variantData = variantRadios.getVariantData();
+  let metaFields = document.querySelectorAll('variant-metafields')[0].getMetafields();
+  suppressInvalidOptions(metaFields, variantData);
+
+  const fieldsets = Array.from(variantRadios.querySelectorAll('fieldset'));
+  const optionGroups = fieldsets.map((fs) => { return Array.from(fs.querySelectorAll('input'))  });
+  const labelGroups = fieldsets.map((fs) => { return Array.from(fs.querySelectorAll('label'))  });
+  optionGroups.forEach((og, i) => {
+    const labelGroup = labelGroups[i];
+    let availableVariants = og.map((option, j) => {
+      let availableVariant = variantData.find((variant) => {
+        return variant.options[i] === option.value && variant.available  });
+      if (!availableVariant) {
+        option.style.display = 'none';
+        labelGroups[i][j].style.display = 'none';
+      }
+    });
+  });
+
+  variantRadios.onVariantChange();
 });

--- a/assets/inventables.js
+++ b/assets/inventables.js
@@ -20,21 +20,25 @@ function suppressInvalidOptions(metaFields, variantData) {
   });
 }
 
-
-
 document.addEventListener('DOMContentLoaded', () => {
   let variantRadios = document.querySelectorAll('variant-radios')[0];
   let variantData = variantRadios.getVariantData();
   let metaFields = document.querySelectorAll('variant-metafields')[0].getMetafields();
+
+  // First, disable the ability to select any options marked as unavailable in metafields.
   suppressInvalidOptions(metaFields, variantData);
 
   const fieldsets = Array.from(variantRadios.querySelectorAll('fieldset'));
   const optionGroups = fieldsets.map((fs) => { return Array.from(fs.querySelectorAll('input'))  });
   const labelGroups = fieldsets.map((fs) => { return Array.from(fs.querySelectorAll('label'))  });
   optionGroups.forEach((og, i) => {
+
+    // If the currently checked option is not available, we need to reset to an available one.
     const availableOptions = [];
     let needsReset = false;
 
+    // Go through each option, and if it's not available, hide it. If it is available, mark it as such, in
+    // case we need to reset to it.
     og.forEach((option, j) => {
       let availableVariant = variantData.find((variant) => {
         return variant.options[i] === option.value && variant.available  });

--- a/assets/inventables.js
+++ b/assets/inventables.js
@@ -1,0 +1,30 @@
+class VariantMetafields extends HTMLElement {
+  constructor() {
+    super();
+  }
+
+  getMetafields() {
+    this.metafields = this.metafields || this.querySelector('[type="application/json"]').textContent;
+    return this.metafields;
+  }
+}
+
+customElements.define('variant-metafields', VariantMetafields);
+
+function suppressInvalidOptions() {
+  let metaFields = JSON.parse(document.querySelectorAll('variant-metafields')[0].getMetafields());
+  let variantSelect = document.querySelectorAll('variant-selects, variant-radios')[0]
+  let variantData = variantSelect.getVariantData();
+  variantData.forEach((variant) => {
+    let metaField = metaFields[variant.id];
+    if (metaField) {
+      variant.available = metaFields[variant.id].available;
+    }
+  });
+}
+
+document.addEventListener('DOMContentLoaded', () => {
+  suppressInvalidOptions();
+  let variantSelect = document.querySelectorAll('variant-selects, variant-radios')[0];
+  variantSelect.onVariantChange();
+});

--- a/layout/inventables.liquid
+++ b/layout/inventables.liquid
@@ -31,6 +31,7 @@
     {% render 'meta-tags' %}
 
     <script src="{{ 'global.js' | asset_url }}" defer="defer"></script>
+    <script src="{{ 'inventables.js' | asset_url }}" defer="defer"></script>
     <script src="{{ 'affirm.js' | asset_url }}" defer="defer"></script>
     <script src="{{ 'xcp-modal.js' | asset_url }}" defer="defer"></script>
 

--- a/layout/theme.liquid
+++ b/layout/theme.liquid
@@ -92,6 +92,7 @@
     {% render 'meta-tags' %}
 
     <script src="{{ 'global.js' | asset_url }}" defer="defer"></script>
+    <script src="{{ 'inventables.js' | asset_url }}" defer="defer"></script>
     <script src="{{ 'affirm.js' | asset_url }}" defer="defer"></script>
     <script src="{{ 'xcp-modal.js' | asset_url }}" defer="defer"></script>
 

--- a/sections/main-product.liquid
+++ b/sections/main-product.liquid
@@ -47,6 +47,18 @@
     >
   {%- endif -%}
 
+  <variant-metafields>
+    <script type="application/json">
+      {
+        {% for variant in product.variants %}
+          "{{ variant.id }}": {
+            "available": {{ variant.metafields.custom.available_for_purchase |  metafield_text |  default: true }}
+          }{%- unless forloop.last -%},{%- endunless -%}
+        {% endfor %}
+      }
+    </script>
+  </variant-metafields>
+
   <div class="product product--{{ section.settings.media_size }} product--{{ section.settings.media_position }} product--{{ section.settings.gallery_layout }} grid grid--1-col {% if product.media.size > 0 %}grid--2-col-tablet{% else %}product--no-media{% endif %}">
     <div class="grid__item product__media-wrapper{% if section.settings.media_position == 'right' %} medium-hide large-up-hide{% endif %}">
       <media-gallery
@@ -556,6 +568,10 @@
                         <option
                           {% if variant == product.selected_or_first_available_variant %}
                             selected="selected"
+                          {% endif %}
+                          {%  assign available_for_purchase =  variant.metafields.custom.available_for_purchase | metafield_text |  default: true %}
+                          {% if available_for_purchase == "false" %}
+                            disabled
                           {% endif %}
                           {% if variant.available == false %}
                             disabled


### PR DESCRIPTION
This PR includes logic to hide any variants that are unavailable for purchase. 

This was complicated by the fact that Dawn doesn't list variants explicitly on the product page. 
Instead, it lists the _options_ made available by those variants (e.g., size, color, etc), when when those options are selected, it looks for a variant that matches that combination of options. If such a variant does not exist, the "add to cart" button is disabled. 

We want to extend that behavior to consider any unavailable variants as unavailable in the above logic (finding the variant that matches the selected options). We also want to hide any options for which _no_ variants are available. (For example, if we sell something that comes in red, yellow, and green, but all the green variants are disabled, we also want to hide the green option). 

Here's how it works: 

### Metafield
We have a metafield on variants to indicate if the variant is available for purchase. If not set, we default to true.  This can be set in the admin UI, though I intend to write a script to set it for everything unavailable from the FBolt DB

<img width="681" alt="Screen Shot 2023-05-19 at 1 24 3 0 PM" src="https://github.com/Shopify/dawn/assets/899/561c4963-2a81-4196-82e9-7ccd7ffa3fcd">

### Disabling and hiding

We load the metafied on the product page using a custom HTML element - `<variant-metafields>`. 
In `inventables.js`, once the DOM has loaded, we use the values in those metafields mark any unavailable variants as disabled in the variant data that the page uses. (Loaded in the `<variant-radios>` element in `global.js`. 
We then go through each option and search the variants to see if there is an available variant with that option. If not, we hid the option. 

### Selecting an available variant
It's possible that the default selected option is unavailable. If that's the case, we select the first available option. 
