### PR TITLE
load login iframe earlier in the page lifecycle

### DIFF
--- a/sections/shopify-login.liquid
+++ b/sections/shopify-login.liquid
@@ -7,7 +7,7 @@
   </div>
 
   <div id="login" class="inventables__shopify-login">
-    <iframe id="logout" src="{{ shop.metafields.development.local_address }}/logout" style="border: none; height: 520px; width: 0px;">
+    <iframe id="logout" src="{{ shop.metafields.development.local_address }}/logout" style="border: none; height: 0px; width: 0px;">
     </iframe>
   </div>
 </div>

--- a/sections/shopify-login.liquid
+++ b/sections/shopify-login.liquid
@@ -7,15 +7,14 @@
   </div>
 
   <div id="login" class="inventables__shopify-login">
-    <iframe id="logout" scrolling="no" src="{{ shop.metafields.development.local_address }}/logout" style="border: none; height: 0px; width: 0px;">
+    <iframe id="logout" src="{{ shop.metafields.development.local_address }}/logout" style="border: none; height: 520px; width: 0px;">
     </iframe>
   </div>
 </div>
 <script type="text/javascript">
-  window.onload = function() {
+  window.addEventListener("DOMContentLoaded", () => {
     let loginDiv = document.getElementById("login");
     let loginForm = document.createElement("iframe");
-    loginForm.scrolling = "no";
     loginForm.style = "border: none;";
     loginForm.id="inventables";
 
@@ -23,18 +22,18 @@
     let iframeSource = "{{ shop.metafields.development.local_address }}/shopify/login_form?" + searchParams.toString();
     loginForm.setAttribute("src", iframeSource);
     loginDiv.appendChild(loginForm);
-  }
+  });
 
   window.addEventListener("message", (event) => {
     if (event.origin === "{{ shop.metafields.development.local_address }}") {
       var data = JSON.parse(event.data);
       if (data.authenticated) {
-        window.location.href = data.target_url;        
+        window.location.href = data.target_url;
       } else if (data.error_message) {
         document.getElementsByClassName("inventables__shopify-login__flash-message__text")[0].innerHTML = data.error_message;
-      } 
+      }
     }
-  }, false);
+  });
 </script>
 
 {%- style -%}


### PR DESCRIPTION
I noticed that the login page was loading really slowly. This PR addresses that. 

On investigation, the login page is loading a lot of assets (including a large video), and the iframe contents w/ the username and password weren't loading until after those. It would sometimes take a few seconds before the login form appeared, and it would appear that the page was broken. 

This PR addresses that problem by moving the loading of the iframe contents to earlier in the page load process so we don't wait until all the assets (fonts, CSS, videos, etc) are loading before doing so. 

In testing, the second item made a big difference in the page load experience. 





