### PR TITLE
added tag for google ads to work

### DIFF
--- a/layout/theme.liquid
+++ b/layout/theme.liquid
@@ -495,6 +495,16 @@
   
 
   {% render 'shogun-head' %}
+
+  <!-- Google tag (gtag.js) -->
+  <script async src="https://www.googletagmanager.com/gtag/js?id=AW-952042577"></script>
+  <script>
+    window.dataLayer = window.dataLayer || [];
+    function gtag(){dataLayer.push(arguments);}
+    gtag('js', new Date());
+    gtag('config', 'AW-952042577');
+  </script>
+
 </head>
 
   <body class="gradient">


### PR DESCRIPTION
This adds a snippet that enables Google Ads conversion tracking on all web pages.

This follows the guide at https://help.shopify.com/en/manual/promoting-marketing/analyze-marketing/tracking-adwords-conversions