### PR TITLE
fixes an undefined error

### DIFF
--- a/assets/inventables.js
+++ b/assets/inventables.js
@@ -22,6 +22,9 @@ function suppressInvalidOptions(metaFields, variantData) {
 
 document.addEventListener('DOMContentLoaded', () => {
   let variantRadios = document.querySelectorAll('variant-radios')[0];
+  if (variantRadios == null) {
+    return;
+  }
   let variantData = variantRadios.getVariantData();
   let metaFields = document.querySelectorAll('variant-metafields')[0].getMetafields();
 


### PR DESCRIPTION
When `variantRadios` comes back as `undefined` the script breaks and somehow interferes with Google tracking for add to cart events.