### PR TITLE
Add GTM snippet back into `theme.liquid`

### DIFF
--- a/layout/theme.liquid
+++ b/layout/theme.liquid
@@ -16,13 +16,6 @@
 
     {%- assign production_shop_id = 60429828153 -%}
     {%- assign staging_shop_id = 67711828243 -%}
-    {% unless page.template_suffix == 'cabinet-beta-landing' or shop.id == staging_shop_id %}
-      {% unless admin %}
-        <script>
-          // window.location.href = 'https://inventables.com'
-        </script>
-      {% endunless %}
-    {% endunless %}
 
     {%- case shop.id -%}
       {%- when production_shop_id -%}

--- a/layout/theme.liquid
+++ b/layout/theme.liquid
@@ -16,6 +16,39 @@
 
     {%- assign production_shop_id = 60429828153 -%}
     {%- assign staging_shop_id = 67711828243 -%}
+    {% unless page.template_suffix == 'cabinet-beta-landing' or shop.id == staging_shop_id %}
+      {% unless admin %}
+        <script>
+          // window.location.href = 'https://inventables.com'
+        </script>
+      {% endunless %}
+    {% endunless %}
+
+    {%- case shop.id -%}
+      {%- when production_shop_id -%}
+      {%- assign google_tag_manager_container_id = 'GTM-5H85H3N' -%}
+      {%- when staging_shop_id -%}
+      {%- assign google_tag_manager_container_id = 'GTM-TG2KSNK' -%}
+    {%- endcase %}
+
+    {%- unless google_tag_manager_container_id == blank -%}
+      <!-- Google Tag Manager -->
+      <script>
+        (function(w, d, s, l, i) {
+          w[l] = w[l] || [];
+          w[l].push({'gtm.start': new Date().getTime(), event: 'gtm.js'});
+          var f = d.getElementsByTagName(s)[0],
+            j = d.createElement(s),
+            dl = l != 'dataLayer'
+              ? '&l=' + l
+              : '';
+          j.async = true;
+          j.src = 'https://www.googletagmanager.com/gtm.js?id=' + i + dl;
+          f.parentNode.insertBefore(j, f);
+        })(window, document, 'script', 'dataLayer','{{ google_tag_manager_container_id }}');
+      </script>
+      <!-- End Google Tag Manager -->
+    {%- endunless -%}
 
     <meta charset="utf-8">
     <meta http-equiv="X-UA-Compatible" content="IE=edge">

--- a/layout/xcp.liquid
+++ b/layout/xcp.liquid
@@ -17,14 +17,6 @@
     {%- assign production_shop_id = 60429828153 -%}
     {%- assign staging_shop_id = 67711828243 -%}
 
-    {% unless page.template_suffix == 'cabinet-beta-landing' or shop.id == staging_shop_id %}
-      {% unless admin %}
-        <script>
-          // window.location.href = 'https://inventables.com'
-        </script>
-      {% endunless %}
-    {% endunless %}
-
     {%- case shop.id -%}
       {%- when production_shop_id -%}
       {%- assign google_tag_manager_container_id = 'GTM-5H85H3N' -%}


### PR DESCRIPTION
We thought this was deprecated, but I think only the `checkout.liquid` is deprecated and `theme.liquid` still needs the snippet in order for GTM to work.