### PR TITLE
Remove "cover_image" setting from xcp-video

### DIFF
--- a/sections/xcp-video.liquid
+++ b/sections/xcp-video.liquid
@@ -214,11 +214,6 @@
       "default": 73
     },
     {
-      "type": "image_picker",
-      "id": "cover_image",
-      "label": "t:sections.video.settings.cover_image.label"
-    },
-    {
       "type": "text",
       "id": "description",
       "label": "t:sections.video.settings.description.label",


### PR DESCRIPTION
### PR Summary: 

Remove "cover_image" setting from xcp-video.

Poster is set through Vimeo.