### PR TITLE
Replace footer bottom content with simpler styling

### DIFF
--- a/assets/section-footer.css
+++ b/assets/section-footer.css
@@ -569,7 +569,7 @@ noscript .localization-selector.link {
 }
 
 .footer__social-link {
-  margin-right: 30px;
+  margin-right: 20px;
 }
 
 .footer__social-link:last-child {
@@ -580,7 +580,7 @@ noscript .localization-selector.link {
 .footer__social-icon {
   color: #FEA245;
   display: inline-block;
-  font-size: 30px;
+  font-size: 26px;
 }
 
 .footer__social-icon:hover {
@@ -726,3 +726,43 @@ noscript .localization-selector.link {
   margin-bottom: 10px;
 }
 
+.footer-bottom {
+  list-style-type: none;
+  padding: 0;
+  padding-top: 20px;
+  padding-bottom: 20px;
+  margin: 0;
+  font-family: Alright Sans LT,lato,helvetica,sans-serif;
+  font-size: 14px;
+  color: #e4e4e4;
+}
+
+@media screen and (min-width: 750px) {
+  .footer-bottom {
+    display: flex;
+    flex-direction: column;
+    justify-content: center;
+    align-items: center;
+    max-width: 400px;
+    margin: 0 auto;
+  }
+}
+
+.footer-bottom .footer-bottom__text {
+  font-size: 12px;
+  color: #e4e4e4;
+  text-decoration: none;
+}
+
+.copyright-inventables-inc {
+  line-height: calc(1 + 0.8 / var(--font-body-scale));
+  padding-bottom: 1rem;
+  padding-top: 1rem;
+}
+
+@media screen and (min-width: 750px) {
+  .copyright-inventables-inc {
+    padding-bottom: 0.5rem;
+    padding-top: 0.5rem;
+  }
+}

--- a/sections/footer.liquid
+++ b/sections/footer.liquid
@@ -98,47 +98,37 @@
               </div>
             {%- endfor -%}
           </div>
-          <div class="invitation-card">
-              <div class="invitation-section email-support">
-                <div class="footer-wrapper">
-                  <a href="https://inventables.zendesk.com/hc/en-us/requests/new">
-                  <span>Email Support</span>
-                  <img src="https://d2rhdy377k7eul.cloudfront.net/assets/xcarve2_5/right_top_arrow_icon-b647e7935a576bc862f976ef1f7cc1c26b947fa88e6fc5b50faa1ea29bf79633.svg">
-                  </a>
-                </div>
-              </div>
-              <div class="invitation-section phone">
-                <div class="footer-wrapper">
-                  <span class="footer-wrapper__phone">
-                    <img src="https://d2rhdy377k7eul.cloudfront.net/assets/xcarve2_5/phone_icon-a636ea181872736d47e6d762029d3c478051f97848c22e5a3ffd23a1246eaa38.svg">
-                    <p>312 775 7009</p>
-                  </span>
-                </div>
-              </div>
-              <div class="invitation-section copy-right">
-                <div class="footer-wrapper">
-                  <span class="footer-wrapper__copy-right">
-                    <p>© INVENTABLES, INC. 2023</p><span>|</span>
-                    <p><a target="_blank" href="/privacy_policy">Privacy Policy</a></p><span>|</span>
-                    <p><a target="_blank" href="/terms_of_use">Terms of Use</a></p>
-                  </span>
-                </div>
-              </div>
-              <div class="social invitation-section">
-                <div class="footer-wrapper">
-                  <a target="_blank" class="footer__link footer__social-link" href="https://www.instagram.com/inventables/?hl=en">
-                    <i class="fa fa-instagram footer__social-icon"></i>
-                  </a>
-                  <a target="_blank" class="footer__link footer__social-link" href="https://www.facebook.com/Inventables/">
-                    <i class="fa fa-facebook footer__social-icon"></i>
-                  </a>
-                  <a target="_blank" class="footer__link footer__social-link" href="https://twitter.com/inventables">
-                    <i class="fa fa-twitter footer__social-icon"></i>
-                  </a>
-                </div>
-              </div>
-            </div>
-          </div>
+
+          <ul class="footer__content-bottom footer-bottom">
+            <li>
+              <a target="_blank" class="link footer__social-link" href="https://www.instagram.com/inventables/?hl=en">
+                <i class="fa fa-instagram footer__social-icon"></i>
+              </a>
+              <a target="_blank" class="link footer__social-link" href="https://www.facebook.com/Inventables/">
+                <i class="fa fa-facebook footer__social-icon"></i>
+              </a>
+              <a target="_blank" class="link footer__social-link" href="https://twitter.com/inventables">
+                <i class="fa fa-twitter footer__social-icon"></i>
+              </a>
+            </li>
+            <li>
+              <a class="footer-bottom__text" href="https://inventables.zendesk.com/hc/en-us/requests/new">
+                Email Support
+              </a>
+            </li>
+            <li>
+              <a class="footer-bottom__text" href="tel:312-775-7009">(312) 775-7009</a>
+            </li>
+            <li>
+              <a class="footer-bottom__text" target="_blank" href={{ shop.privacy_policy.url }}>Privacy Policy</a>
+              &nbsp;|&nbsp;
+              <a class="footer-bottom__text" target="_blank" href={{ shop.terms_of_service.url }}>Terms of Use</a>
+            </li>
+            <li>
+              <span class="footer-bottom__text copyright-inventables-inc">© INVENTABLES, INC. 2023</span>
+            </li>
+          </ul>
+
         {%- endif -%}
       </div>
     {%- endif -%}


### PR DESCRIPTION
**What this PR does**

Replaces the footer bottom content with a simpler design

**Context**

I noticed the privacy policy and terms of use links were incorrect. While working on this I wanted to redo this section because the style is less than ideal.

**How to test**

I tested this on my machine against my development store by running `shopify theme serve`. I then connected this branch to the production store and previewed the theme:

<img width="628" alt="SCR-20230712-mmfm" src="https://github.com/inventables/ecomm-theme-dawn/assets/26750330/6459511a-e7f1-40e4-b324-8936d202b31f">
<img width="1161" alt="SCR-20230712-mmgx" src="https://github.com/inventables/ecomm-theme-dawn/assets/26750330/12bcc2c8-7f00-46b3-8b7b-29e551783093">
