### PR TITLE
Make Xcp affirm financing editable in the theme editor

### DIFF
--- a/sections/xcp-product.liquid
+++ b/sections/xcp-product.liquid
@@ -1361,6 +1361,12 @@
           "type": "color",
           "label": "Price Color",
           "default": "#FFB762"
+        },
+        {
+          "id": "affirm_text",
+          "type": "richtext",
+          "label": "Affirm Text",
+          "default": "<p><strong>0% Interest Financing</strong> payments begin after the unit ships</p>"
         }
       ]
     },

--- a/snippets/xcp-affirm.liquid
+++ b/snippets/xcp-affirm.liquid
@@ -27,6 +27,6 @@
   <div class="affirm-as-low-as" data-learnmore-show="true" data-page-type="product" data-affirm-color="white" data-amount="{{ product.selected_or_first_available_variant.price  }}"></div>
 
   <div class="kit-select__affirm-explanation-message">
-    <strong>0% Interest Financing</strong> payments begin after the unit ships
+    {{ affirm_text }}
   </div>
 </div>

--- a/snippets/xcp-price.liquid
+++ b/snippets/xcp-price.liquid
@@ -106,6 +106,6 @@
     </span>
   {%- endif -%}
   <div>
-    {% render "xcp-affirm" %}
+    {% render "xcp-affirm", affirm_text: settings.affirm_text %}
   </div> 
 </div>

--- a/templates/product.x-carve-product.json
+++ b/templates/product.x-carve-product.json
@@ -64,7 +64,8 @@
           "type": "xcp-price",
           "settings": {
             "currency_code_enabled": false,
-            "price_color": "#ffb762"
+            "price_color": "#ffb762",
+            "affirm_text": ""
           }
         },
         "b37b26d9-a398-4859-a781-239451b8a232": {


### PR DESCRIPTION
### PR Summary: 
update affirm text regarding financing for XC by using text from xcp-price settings


### Why are these changes introduced?
XC text needed to be removed,  but we wanted this field to be able to be edited from the theme editor
