### PR TITLE
Set logged_in and admin variables in the header

### DIFF
--- a/config/settings_schema.json
+++ b/config/settings_schema.json
@@ -1508,5 +1508,30 @@
         "info": "t:settings_schema.cart.settings.cart_drawer.collection.info"
       }
     ]
+  },
+  {
+    "name": "Simulate User (Theme Editor Only)",
+    "settings": [
+      {
+        "type": "radio",
+        "id": "simulated_user_type",
+        "label": "User Type",
+        "options": [
+          {
+            "value": "guest",
+            "label": "Guest"
+          },
+          {
+            "value": "buyer",
+            "label": "Buyer"
+          },
+          {
+            "value": "admin",
+            "label": "Admin"
+          }
+        ],
+        "default": "guest"
+      }
+    ]
   }
 ]

--- a/sections/header.liquid
+++ b/sections/header.liquid
@@ -195,22 +195,29 @@
     <script src="{{ 'cart-drawer.js' | asset_url }}" defer="defer"></script>
 {%- endif -%}
 
-{% capture CFH %}
-    {{ content_for_header }}
-{% endcapture %}
+{%- liquid
+  if customer.id != null
+    assign logged_in = true
+  endif
 
-{% if CFH contains 'admin_bar_iframe' %}
-    {% assign admin = true %}
-{% elsif CFH contains 'preview_bar_injector-' %}
-    {% assign admin = true %}
-{% elsif CFH contains 'Online store editor' %}
-    {% assign admin = true %}
-{% elsif CFH contains 'designMode' %}
-    {% assign admin = true %}
-{% endif %}
-{% if customer.id != null %}
-    {% assign logged_in = true %}
-{% endif %}
+  if logged_in and customer.tags contains "admin"
+    assign admin = true
+  endif
+
+  comment ## ADMIN THEME EDITOR ONLY
+  endcomment
+  if request.design_mode
+    case settings.simulated_user_type
+      when "guest"
+        assign logged_in = false
+      when "buyer"
+        assign logged_in = true
+      when "admin"
+        assign logged_in = true
+        assign admin     = true
+    endcase
+  endif
+-%}
 
 <div class="container">
 </div>


### PR DESCRIPTION
### PR Summary: 

1. Sets `admin = true` if the user is logged in and the customer object is tagged with "admin"

2. Adds a theme setting so it's easier to test UI that depends on whether a customer is logged in and whether they are an admin

### Why are these changes introduced?

Fixes https://github.com/inventables/fbolt/issues/6293

### Context and approach

#### 1. `admin` check

The gear icon that toggles the admin link dropdown stopped showing because our admin check (`CFH contains 'admin_bar_iframe'`) stopped working. 

Unfortunately, this was the suggestion in the [most popular support article on the topic](https://community.shopify.com/c/technical-q-a/detect-admin-shop-owner-logged-into-store/m-p/2069680/highlight/true#M127659) and this [related SO post](https://stackoverflow.com/questions/17470921/how-to-check-if-current-visitor-is-shops-admin).

I also chatted with Shopify Plus Support, and they confirmed there is no simple check to determine if the logged in customer is an admin for the organization.

Additionally, the [Shopify theme check utility warns](https://github.com/Shopify/theme-check/blob/main/docs/checks/content_for_header_modification.md) not to depend on the contents of `content_for_header`–which is what we did, and the rug was pulled out from under us.

I think the simplest way to manage this is with customer tags. This unfortunately means we need to manage admin users in both the customer admin UI and the organization settings. We may mitigate this by passing `tag_string` in the [multipass request](https://shopify.dev/docs/api/multipass).

I created an Admins customer segment to easily see who has that "admin" tag:

<img width="590" alt="image" src="https://github.com/inventables/ecomm-theme-dawn/assets/26750330/4b6c5b4e-6921-44c0-b353-7fe9c266a56b">

#### 2. Theme setting to simulate user

This PR also adds a theme setting to simulate user types in the theme editor.

This is currently scoped to the header, but it might be useful elsewhere.

In the Theme Editor you can navigate to Theme Settings and toggle between "guest", "buyer" (logged in, but not admin), and "admin" types. This uses [`request.design_mode`](https://shopify.dev/docs/api/liquid/objects#request-design_mode), so it has no impact on the theme outside of the editor.

Here's how it's used:

https://github.com/inventables/ecomm-theme-dawn/assets/26750330/33de8fe5-18ff-4927-ac5b-54393a94a116


