### PR TITLE
Add ids to Easel page sections for anchors

### DIFF
--- a/config/settings_data.json
+++ b/config/settings_data.json
@@ -306,21 +306,21 @@
             "type": "nav_item",
             "settings": {
               "text": "Overview",
-              "url": ""
+              "url": "#overview"
             }
           },
           "ca01df36-f770-4ec4-b8a5-8e5a6456cfaa": {
             "type": "nav_item",
             "settings": {
               "text": "Compare Plans",
-              "url": ""
+              "url": "#plans"
             }
           },
           "1e2c194c-0698-4a2e-8b04-5fbf8a81c570": {
             "type": "nav_item",
             "settings": {
               "text": "Supported Hardware",
-              "url": "#easel-supported-hardware"
+              "url": "#compatible-machines"
             }
           }
         },

--- a/sections/easel-all-in-one.liquid
+++ b/sections/easel-all-in-one.liquid
@@ -89,7 +89,7 @@
 }
 {% endstyle %}
 
-<div class="easel-aio section-{{ section.id }}">
+<div id="overview" class="easel-aio section-{{ section.id }}">
   <div class="easel-aio__container">
     <p class="easel-aio__title">{{ section.settings.title }}</p>
     <div class="easel-aio__items-wrapper">

--- a/sections/easel-plans.liquid
+++ b/sections/easel-plans.liquid
@@ -112,7 +112,7 @@
   }
 }
 {% endstyle %}
-<div class="easel-plans section-{{ section.id }}">
+<div id="plans" class="easel-plans section-{{ section.id }}">
   <div class="easel-plans__container">
     <p class="easel-plans__title">{{ section.settings.title }}</p>
     <p class="easel-plans__subtitle">{{ section.settings.subtitle }}</p>

--- a/sections/easel-supported-hardware.liquid
+++ b/sections/easel-supported-hardware.liquid
@@ -14,7 +14,7 @@
     vertical-align: middle;
     border: 0;
   }
-  
+
   .easel-support-hardware__square-wrapper {
     font-size: 12pt;
     line-height: 18pt;
@@ -207,7 +207,7 @@
   }
 {% endstyle %}
 
-<div id="easel-supported-hardware" class="easel-supported-hardware__container">
+<div id="compatible-machines" class="easel-supported-hardware__container">
 
   <div class="easel-support-hardware__detail-wrapper">
     <div class="easel-support-hardware__square-wrapper">


### PR DESCRIPTION
**What does this PR do?**

^^

**Background Context and Screenshots**

After merging #81 and checking the links, I noticed we are missing IDs for these links to anchor to:

<img width="1074" alt="image" src="https://github.com/inventables/ecomm-theme-dawn/assets/26750330/f15b5192-ac8b-4c68-b19e-c503780799ae">

**What steps did you take to test your changes?**

- [x] Test this on the Production Store by connecting this branch of the theme


https://github.com/inventables/ecomm-theme-dawn/assets/26750330/131fa884-930b-4fed-8f66-4401fd4d0811

