### PR TITLE
fix: handle vimeo url

### DIFF
--- a/sections/easel-get-more.liquid
+++ b/sections/easel-get-more.liquid
@@ -87,17 +87,21 @@
                 class="js-youtube"
                 allow="autoplay; encrypted-media"
                 allowfullscreen
-                title="{{ section.settings.description | escape }}"
-              ></iframe>
+                title="{{ section.settings.description | escape }}"></iframe>
             {%- else -%}
+              {% assign video_url_first_path = section.settings.video | split: ".com/" | last | split: "/" | first %}
+              {% assign video_url_last_path = section.settings.video | split: ".com/" | last | split: "/" | last %}
+              {% assign video_url = "https://player.vimeo.com/video/" | append: video_url_first_path %}
+              {% if video_url_first_path != video_url_last_path %}
+                {% assign video_url = video_url | append: "?h=" | append: video_url_last_path %}
+              {% endif %}
               <iframe
-                src="https://player.vimeo.com/video/{{ video_id }}"
+                src="{{ video_url }}"
                 sandbox="allow-presentation allow-scripts allow-same-origin"
                 class="js-vimeo"
                 allow="autoplay; encrypted-media"
                 allowfullscreen
-                title="{{ section.settings.description | escape }}"
-              ></iframe>
+                title="{{ section.settings.description | escape }}"></iframe>
             {%- endif -%}
           {% endif %}
         </div>


### PR DESCRIPTION
### PR Summary: 

Add a vimeo url handling to consider url with more than 1 path in url path, and adapt to fit in the iframe path correctly

### Why are these changes introduced?

The vimeo url was crashing by change to a url with more than 1 path

### What approach did you take?

Split the patch in different variables and mount according the url pattern expected by iframe

### Visual impact on existing themes
None

