### PR TITLE
Add Cookie Banner to Shopify

### DIFF
--- a/assets/cookie-banner.css
+++ b/assets/cookie-banner.css
@@ -1,0 +1,49 @@
+.cookie-banner {
+  position: fixed;
+  bottom: 0;
+  left: 0;
+  width: 100%;
+  font-size: 14px;
+  background-color: #171b1f;
+  padding: 0 20px 20px 20px;
+  color: rgba(250, 249, 246, 0.75);
+}
+
+@media screen and (min-width: 750px) {
+  .cookie-banner {
+    width: 60%;
+    bottom: 30px;
+    left: 30px;
+    border-radius: 6px;
+  }
+}
+
+@media screen and (min-width: 1200px) {
+  .cookie-banner {
+    width: 40%;
+  }
+}
+
+.cookie-banner a {
+  color: rgba(250, 249, 246, 0.75);
+}
+
+.cookie-banner__btn-group {
+  display: flex;
+  justify-content: flex-end;
+}
+
+.cookie-banner__btn--acknowledge {
+  padding: 10px 18px;
+  background-color: #ffb256;
+  color: #171b1f;
+  border: none;
+  font-size: 1.4rem;
+  border-radius: 3px;
+  font-weight: bold;
+  cursor: pointer;
+}
+
+.cookie-banner__btn--acknowledge:hover {
+  cursor: pointer;
+}

--- a/assets/cookie-banner.css
+++ b/assets/cookie-banner.css
@@ -34,7 +34,7 @@
   justify-content: flex-end;
 }
 
-.cookie-banner__btn--acknowledge {
+.cookie-banner__btn--ok {
   padding: 10px 18px;
   background-color: #ffb256;
   color: #171b1f;
@@ -45,6 +45,6 @@
   cursor: pointer;
 }
 
-.cookie-banner__btn--acknowledge:hover {
+.cookie-banner__btn--ok:hover {
   cursor: pointer;
 }

--- a/assets/cookie-banner.css
+++ b/assets/cookie-banner.css
@@ -2,6 +2,7 @@
   position: fixed;
   bottom: 0;
   left: 0;
+  z-index: 2;
   width: 100%;
   font-size: 14px;
   background-color: #171b1f;

--- a/config/settings_schema.json
+++ b/config/settings_schema.json
@@ -1533,5 +1533,28 @@
         "default": "guest"
       }
     ]
+  },
+  {
+    "name": "Cookie Banner",
+    "settings": [
+      {
+        "type": "checkbox",
+        "id": "cookie_banner_preview",
+        "label": "Preview banner",
+        "default": true
+      },
+      {
+        "type": "html",
+        "id": "cookie_banner_html",
+        "label": "Text (HTML)",
+        "default": "<p><strong>This website uses cookies</strong></p><p>We use cookies to personalize content and to interact with our analytics companies, advertising networks and cooperatives, and demographic companies, and to provide social media features and to analyze our traffic. Our social media, advertising and analytics partners may combine it with other information that you’ve provided to them or that they’ve collected from your use of their services. <a href='https://www.inventables.com/policies/privacy-policy' target='_blank'>Learn more.</a></p>"
+      },
+      {
+        "type": "text",
+        "id": "cookie_banner_button",
+        "label": "Button text",
+        "default": "OK"
+      }
+    ]
   }
 ]

--- a/config/settings_schema.json
+++ b/config/settings_schema.json
@@ -1547,7 +1547,7 @@
         "type": "html",
         "id": "cookie_banner_html",
         "label": "Text (HTML)",
-        "default": "<p><strong>This website uses cookies</strong></p><p>We use cookies to personalize content and to interact with our analytics companies, advertising networks and cooperatives, and demographic companies, and to provide social media features and to analyze our traffic. Our social media, advertising and analytics partners may combine it with other information that you’ve provided to them or that they’ve collected from your use of their services. <a href='https://www.inventables.com/policies/privacy-policy' target='_blank'>Learn more.</a></p>"
+        "default": "<p><strong>This website uses cookies</strong></p><p>We use cookies to personalize content, interact with our analytics companies, advertising networks and cooperatives, and demographic companies, provide social media features, and to analyze our traffic. Our social media, advertising and analytics partners may combine it with other information that you’ve provided to them or that they’ve collected from your use of their services. <a href='https://www.inventables.com/policies/privacy-policy' target='_blank'>Learn more.</a></p>"
       },
       {
         "type": "text",

--- a/layout/easel.liquid
+++ b/layout/easel.liquid
@@ -558,6 +558,8 @@
 
     {% section 'footer' %}
 
+    {% section 'cookie_banner' %}
+
     <ul hidden>
       <li id="a11y-refresh-page-message">{{ 'accessibility.refresh_page' | t }}</li>
       <li id="a11y-new-window-message">{{ 'accessibility.link_messages.new_window' | t }}</li>

--- a/layout/theme.liquid
+++ b/layout/theme.liquid
@@ -519,7 +519,7 @@
         document.documentElement.classList.add('shopify-design-mode');
       }
     </script>
-  
+
 
   {% render 'shogun-head' %}
 
@@ -554,6 +554,8 @@
     </main>
 
     {% section 'footer' %}
+
+    {% section 'cookie_banner' %}
 
     <ul hidden>
       <li id="a11y-refresh-page-message">{{ 'accessibility.refresh_page' | t }}</li>

--- a/layout/xcp.liquid
+++ b/layout/xcp.liquid
@@ -552,6 +552,8 @@
 
     {% section 'footer' %}
 
+    {% section 'cookie_banner' %}
+
     <ul hidden>
       <li id="a11y-refresh-page-message">{{ 'accessibility.refresh_page' | t }}</li>
       <li id="a11y-new-window-message">{{ 'accessibility.link_messages.new_window' | t }}</li>

--- a/sections/cookie_banner.liquid
+++ b/sections/cookie_banner.liquid
@@ -1,0 +1,56 @@
+<script>
+  window.Shopify.loadFeatures(
+    [
+      {
+        name: 'consent-tracking-api',
+        version: '0.1',
+      },
+    ],
+    error => {
+      if (error) { /* noop */ }
+
+      const acknowledgeBtn = document.querySelector('.cookie-banner__btn--acknowledge');
+      const cookieBanner = document.querySelector('.cookie-banner');
+
+      const registerPermissionsAndClose = () => {
+        window.Shopify.customerPrivacy.setTrackingConsent({
+          'analytics': true,
+          'marketing': true,
+          'preferences': true
+        },
+        () => {
+          cookieBanner.style.display = 'none';
+        });
+      };
+
+      acknowledgeBtn.addEventListener('click', registerPermissionsAndClose);
+
+      const shouldShowCookieBanner = () => {
+        const { marketing, analytics, preferences } = Shopify.customerPrivacy.currentVisitorConsent();
+        return [marketing, analytics, preferences].some(permission => permission === '');
+      };
+
+      if (shouldShowCookieBanner()) {
+        cookieBanner.style.display = 'block';
+      }
+
+      {%- if request.design_mode -%}
+        {%- if settings.cookie_banner_preview -%}
+          cookieBanner.style.display = 'block';
+        {%- else -%}
+          cookieBanner.style.display = 'none';
+        {%- endif %}
+      {%- endif -%}
+    }
+  );
+</script>
+
+{{ 'cookie-banner.css' | asset_url | stylesheet_tag }}
+
+<section class="cookie-banner" style="display: none;">
+  {{ settings.cookie_banner_html }}
+
+  <div class="cookie-banner__btn-group">
+    <button class="cookie-banner__btn--acknowledge">{{ settings.cookie_banner_button }}</button>
+  </div>
+</section>

--- a/sections/cookie_banner.liquid
+++ b/sections/cookie_banner.liquid
@@ -1,56 +1,57 @@
-<script>
-  window.Shopify.loadFeatures(
-    [
-      {
-        name: 'consent-tracking-api',
-        version: '0.1',
-      },
-    ],
-    error => {
-      if (error) { /* noop */ }
-
-      const acknowledgeBtn = document.querySelector('.cookie-banner__btn--acknowledge');
-      const cookieBanner = document.querySelector('.cookie-banner');
-
-      const registerPermissionsAndClose = () => {
-        window.Shopify.customerPrivacy.setTrackingConsent({
-          'analytics': true,
-          'marketing': true,
-          'preferences': true
-        },
-        () => {
-          cookieBanner.style.display = 'none';
-        });
-      };
-
-      acknowledgeBtn.addEventListener('click', registerPermissionsAndClose);
-
-      const shouldShowCookieBanner = () => {
-        const { marketing, analytics, preferences } = Shopify.customerPrivacy.currentVisitorConsent();
-        return [marketing, analytics, preferences].some(permission => permission === '');
-      };
-
-      if (shouldShowCookieBanner()) {
-        cookieBanner.style.display = 'block';
-      }
-
-      {%- if request.design_mode -%}
-        {%- if settings.cookie_banner_preview -%}
-          cookieBanner.style.display = 'block';
-        {%- else -%}
-          cookieBanner.style.display = 'none';
-        {%- endif %}
-      {%- endif -%}
-    }
-  );
-</script>
-
 {{ 'cookie-banner.css' | asset_url | stylesheet_tag }}
 
 <section class="cookie-banner" style="display: none;">
   {{ settings.cookie_banner_html }}
 
   <div class="cookie-banner__btn-group">
-    <button class="cookie-banner__btn--acknowledge">{{ settings.cookie_banner_button }}</button>
+    <button class="cookie-banner__btn--ok">{{ settings.cookie_banner_button }}</button>
   </div>
 </section>
+
+<script>
+  document.addEventListener('DOMContentLoaded', () => {
+    const cookieBanner = document.querySelector('.cookie-banner');
+    const cookieBannerOk = document.querySelector('.cookie-banner__btn--ok');
+
+    const setReadCookiePolicy = () => {
+      document.cookie = `_inv_read_cookie_policy_at=${(new Date).getTime()}; Domain=inventables.com`;
+    };
+
+    const didReadCookiePolicy = () => {
+      return document.cookie.split(';').some(crumb => crumb.trim().startsWith('_inv_read_cookie_policy_at='));
+    };
+
+    const setShopifyTrackingConsent = () => {
+      window.Shopify.loadFeatures(
+        [{ name: 'consent-tracking-api', version: '0.1' }],
+        error => {
+          if (error) { /* noop */ }
+
+          window.Shopify.customerPrivacy.setTrackingConsent({
+            'analytics': true,
+            'marketing': true,
+            'preferences': true
+          }, () => { /* success */ });
+        }
+      );
+    };
+
+    cookieBannerOk.addEventListener('click', () => {
+      cookieBanner.style.display = 'none';
+    });
+
+    if (!didReadCookiePolicy()) {
+      setReadCookiePolicy();
+      setShopifyTrackingConsent();
+      cookieBanner.style.display = 'block';
+    }
+
+    {%- if request.design_mode -%}
+      {%- if settings.cookie_banner_preview -%}
+        cookieBanner.style.display = 'block';
+      {%- else -%}
+        cookieBanner.style.display = 'none';
+      {%- endif %}
+    {%- endif -%}
+  });
+</script>


### PR DESCRIPTION
**What does this PR do?**

Implements a cookie banner on the Shopify Online Store.

- Shows the banner if a cookie named `_inv_read_cookie_policy_at` has not been set
- If it has not been set:
  - Set it
  - And also call `setTrackingConsent`, to set the `'analytics'`, `'marketing'`, and `'preferences'` signals to `true`
- When the visitor clicks "OK", dismiss the banner

In the Theme Editor:
- Allows editing of the cookie banner text (HTML) and the button
- Includes a checkbox to show or hide the banner in the editor

**Background Context and Screenshots**

https://github.com/inventables/ecomm-theme-dawn/assets/26750330/e519e31a-66f3-4a44-b5c9-a1f63510e8fd




https://github.com/inventables/ecomm-theme-dawn/assets/26750330/eada2f9b-565e-4d33-ba73-26cc0fdaca6d




Review the [design review doc](https://docs.google.com/document/d/12X4DasyPNS_bY01bVUTVip8s93t-4KylkHwwveZdq1k/edit) for more context.

**What steps did you take to test your changes?**

Tested it on the production store using `shopify theme serve`

**Link to the relevant Github Issue**

Part of https://github.com/inventables/fbolt/issues/6208

---


**Does anything need to be done before or after deploying this?**


**Who needs to be notified about these changes?**