### PR TITLE
Use block setting for Calendly button text on desktop

### DIFF
--- a/sections/xcp-navbar.liquid
+++ b/sections/xcp-navbar.liquid
@@ -155,7 +155,7 @@
               data-target="calendly-modal-trigger"
               data-modal-target="xcp-demo__modal"
               data-modal-target-closed="xcp-demo__modal--closed"
-              data-modal-closer="xcp-demo__modal-close">Schedule A Call</button>
+              data-modal-closer="xcp-demo__modal-close">{{ schedule_call_block.settings.label }}</button>
           </li>
         {%- endif -%}
         {%- if order_now_block -%}
@@ -385,7 +385,7 @@ Custom Mobile Nav
             "type": "text",
             "id": "label",
             "label": "Label",
-            "default": "Schedule a Call"
+            "default": "Schedule a Demo"
           }
         ]
       }, {

--- a/templates/page.x-carve-faq.json
+++ b/templates/page.x-carve-faq.json
@@ -61,7 +61,7 @@
         "89af13b9-c589-4091-8074-1583339fd706": {
           "type": "xcp-nav-schedule-a-call",
           "settings": {
-            "label": "Schedule a Call"
+            "label": "Schedule a Demo"
           }
         },
         "50ced185-2b56-49be-b5db-c657a065c8fa": {

--- a/templates/page.x-carve-pro-faq.json
+++ b/templates/page.x-carve-pro-faq.json
@@ -60,7 +60,7 @@
         "fcc0921d-bbd3-496a-b92b-dbe9b5140951": {
           "type": "xcp-nav-schedule-a-call",
           "settings": {
-            "label": "Schedule a Call"
+            "label": "Schedule a Demo"
           }
         },
         "7b4ba496-2bb2-422c-821c-5ed11faf0751": {

--- a/templates/page.x-carve-pro-overview.json
+++ b/templates/page.x-carve-pro-overview.json
@@ -53,7 +53,7 @@
         "6bc1b475-c96a-4c9a-a880-4394819234a4": {
           "type": "xcp-nav-schedule-a-call",
           "settings": {
-            "label": "Schedule a Call"
+            "label": "Schedule a Demo"
           }
         },
         "020fbbdf-3bd0-4f0d-a773-d0f7e46b4199": {

--- a/templates/page.x-carve-tech-specs.json
+++ b/templates/page.x-carve-tech-specs.json
@@ -52,7 +52,7 @@
         "e31103eb-4d0e-4de2-98bf-5e5e14e323e5": {
           "type": "xcp-nav-schedule-a-call",
           "settings": {
-            "label": "Schedule a Call"
+            "label": "Schedule a Demo"
           }
         },
         "5e2972f9-899b-47f8-99e8-7bf042a288aa": {

--- a/templates/page.xcp-financing.json
+++ b/templates/page.xcp-financing.json
@@ -61,7 +61,7 @@
         "c496e462-8012-42dd-a9bd-455bcd338e03": {
           "type": "xcp-nav-schedule-a-call",
           "settings": {
-            "label": "Schedule a Call"
+            "label": "Schedule a Demo"
           }
         },
         "362e02f7-d716-4369-9469-f4a8f6aa5366": {

--- a/templates/page.xcp-use-cases-cabinets.json
+++ b/templates/page.xcp-use-cases-cabinets.json
@@ -61,7 +61,7 @@
         "c496e462-8012-42dd-a9bd-455bcd338e03": {
           "type": "xcp-nav-schedule-a-call",
           "settings": {
-            "label": "Schedule a Call"
+            "label": "Schedule a Demo"
           }
         },
         "362e02f7-d716-4369-9469-f4a8f6aa5366": {

--- a/templates/page.xcp-use-cases-furniture.json
+++ b/templates/page.xcp-use-cases-furniture.json
@@ -61,7 +61,7 @@
         "c496e462-8012-42dd-a9bd-455bcd338e03": {
           "type": "xcp-nav-schedule-a-call",
           "settings": {
-            "label": "Schedule a Call"
+            "label": "Schedule a Demo"
           }
         },
         "362e02f7-d716-4369-9469-f4a8f6aa5366": {

--- a/templates/page.xcp-use-cases-home-decor.json
+++ b/templates/page.xcp-use-cases-home-decor.json
@@ -61,7 +61,7 @@
         "c496e462-8012-42dd-a9bd-455bcd338e03": {
           "type": "xcp-nav-schedule-a-call",
           "settings": {
-            "label": "Schedule a Call"
+            "label": "Schedule a Demo"
           }
         },
         "362e02f7-d716-4369-9469-f4a8f6aa5366": {

--- a/templates/page.xcp-use-cases-signs.json
+++ b/templates/page.xcp-use-cases-signs.json
@@ -61,7 +61,7 @@
         "c496e462-8012-42dd-a9bd-455bcd338e03": {
           "type": "xcp-nav-schedule-a-call",
           "settings": {
-            "label": "Schedule a Call"
+            "label": "Schedule a Demo"
           }
         },
         "362e02f7-d716-4369-9469-f4a8f6aa5366": {

--- a/templates/product.x-carve-pro-4x2-product.json
+++ b/templates/product.x-carve-pro-4x2-product.json
@@ -53,7 +53,7 @@
         "14f51c9d-94db-4c78-a0be-0d0c5c6c192b": {
           "type": "xcp-nav-schedule-a-call",
           "settings": {
-            "label": "Schedule a Call"
+            "label": "Schedule a Demo"
           }
         }
       },


### PR DESCRIPTION
**What does this PR do?**

Makes the text of the "Schedule a Call" button editable.

This had been working for the mobile sub-nav, but it was hardcoded in the desktop sub-nav.

**Background Context and Screenshots**

<img width="1180" alt="image" src="https://github.com/inventables/ecomm-theme-dawn/assets/26750330/d168cb12-ed06-47de-bfde-f8c066865a39">
<img width="924" alt="image" src="https://github.com/inventables/ecomm-theme-dawn/assets/26750330/208912da-4372-4dc5-af19-238b468235e0">


**What steps did you take to test your changes?**

Tested against the Production Store using `shopify theme serve`

**Link to the relevant Github Issue**

Closes https://github.com/inventables/fbolt/issues/6341

---

**Does anything need to be done before or after deploying this?**

**Who needs to be notified about these changes?**

- [ ] Phil