### PR TITLE
change login process to be a redirect

### DIFF
--- a/sections/shopify-login.liquid
+++ b/sections/shopify-login.liquid
@@ -6,10 +6,7 @@
     <span class="inventables__shopify-login__flash-message__text"></span>
   </div>
 
-  <div id="login" class="inventables__shopify-login">
-    <iframe id="logout" src="{{ shop.metafields.development.local_address }}/logout" style="border: none; height: 0px; width: 0px;">
-    </iframe>
-  </div>
+  <div id="login" class="inventables__shopify-login" style="border: none; height: 0px; width: 0px;"></div>
 </div>
 <script type="text/javascript">
   window.addEventListener("DOMContentLoaded", () => {
@@ -19,7 +16,7 @@
     loginForm.id="inventables";
 
     let searchParams = new URLSearchParams(window.location.search);
-    let iframeSource = "{{ shop.metafields.development.local_address }}/shopify/login_form?" + searchParams.toString();
+    let iframeSource = "{{ shop.metafields.development.local_address }}/shopify/logout?" + searchParams.toString();
     loginForm.setAttribute("src", iframeSource);
     loginDiv.appendChild(loginForm);
   });
@@ -27,11 +24,7 @@
   window.addEventListener("message", (event) => {
     if (event.origin === "{{ shop.metafields.development.local_address }}") {
       var data = JSON.parse(event.data);
-      if (data.authenticated) {
-        window.location.href = data.target_url;
-      } else if (data.error_message) {
-        document.getElementsByClassName("inventables__shopify-login__flash-message__text")[0].innerHTML = data.error_message;
-      }
+      window.location.href = data.target_url;
     }
   });
 </script>

--- a/sections/shopify-login.liquid
+++ b/sections/shopify-login.liquid
@@ -3,7 +3,8 @@
 
 <div class="login-container">
   <div class="inventables__shopify-login__flash-message">
-    <span class="inventables__shopify-login__flash-message__text"></span>
+    You are being redirected to login.
+    <span id="redirect" style="display: none">Click <a class="link link--text" href="">here</a> if you are not redirected.</span>
   </div>
 
   <div id="login" class="inventables__shopify-login" style="border: none; height: 0px; width: 0px;"></div>
@@ -25,41 +26,9 @@
     if (event.origin === "{{ shop.metafields.development.local_address }}") {
       var data = JSON.parse(event.data);
       window.location.href = data.target_url;
+      let redirect = document.getElementById('redirect');
+      redirect.style.removeProperty('display');
+      redirect.querySelector('a').href = data.target_url;
     }
   });
 </script>
-
-{%- style -%}
-  .section-{{ section.id }}-padding {
-    padding-top: {{ section.settings.padding_top | times: 0.75 | round: 0 }}px;
-    padding-bottom: {{ section.settings.padding_bottom | times: 0.75 | round: 0 }}px;
-  }
-
-  @media screen and (min-width: 750px) {
-    .section-{{ section.id }}-padding {
-      padding-top: {{ section.settings.padding_top }}px;
-      padding-bottom: {{ section.settings.padding_bottom }}px;
-    }
-  }
-
-  .login-container {
-    width: 100%;
-    display: flex;
-    justify-content: center;
-    flex-direction: column;
-  background-color: #f5f5f5;
-  }
-
-  .inventables__shopify-login__flash-message {
-    width: 100%;
-    display: flex;
-    justify-content: center;
-    margin-bottom: 20px;
-  }
-
-  .login-frame {
-    height: 200px;
-    width: 50%;
-    border: none;
-  }
-{%- endstyle -%}

--- a/sections/shopify-login.liquid
+++ b/sections/shopify-login.liquid
@@ -6,29 +6,15 @@
     You are being redirected to login.
     <span id="redirect" style="display: none">Click <a class="link link--text" href="">here</a> if you are not redirected.</span>
   </div>
-
-  <div id="login" class="inventables__shopify-login" style="border: none; height: 0px; width: 0px;"></div>
 </div>
+
 <script type="text/javascript">
   window.addEventListener("DOMContentLoaded", () => {
-    let loginDiv = document.getElementById("login");
-    let loginForm = document.createElement("iframe");
-    loginForm.style = "border: none;";
-    loginForm.id="inventables";
-
     let searchParams = new URLSearchParams(window.location.search);
-    let iframeSource = "{{ shop.metafields.development.local_address }}/shopify/logout?" + searchParams.toString();
-    loginForm.setAttribute("src", iframeSource);
-    loginDiv.appendChild(loginForm);
-  });
-
-  window.addEventListener("message", (event) => {
-    if (event.origin === "{{ shop.metafields.development.local_address }}") {
-      var data = JSON.parse(event.data);
-      window.location.href = data.target_url;
-      let redirect = document.getElementById('redirect');
-      redirect.style.removeProperty('display');
-      redirect.querySelector('a').href = data.target_url;
-    }
+    let destination = "{{ shop.metafields.development.local_address }}/shopify/logout?" + searchParams.toString();
+    window.location.href = destination;
+    let redirect = document.getElementById('redirect');
+    redirect.style.removeProperty('display');
+    redirect.querySelector('a').href = destination;
   });
 </script>

--- a/templates/customers/login.json
+++ b/templates/customers/login.json
@@ -1,5 +1,4 @@
 {
-  "layout": "inventables",
   "sections": {
     "main": {
       "type": "shopify-login",


### PR DESCRIPTION
#### What does this PR do?

This changes the login page to redirect to site.inventables.com for login rather than load the login form in the iframe. 
#### Background Context and Screenshots

We want to remove steps in the checkout process. 

#### What steps did you take to test your changes?

Using shopify theme dev and running fbolt locally, I:

 - Logged out. Added items to my cart. Saw that I was directed to login. Logged in. Saw that I was on the checkout page
 - Logged out. Added items to my cart. Saw that I was directed to login. Created a new account. Saw that I was on the checkout page
 - On the checkout page, clicked `logout`. Saw that I was prompted to login. Logged in. Saw that I was back to the checkout page. 
 - On shopify, went to `https://{store}/account/login`. Verified I was logged out on fbolt (observing the navbar). Logged in. Saw that I was sent to the cart page (the default with no return_to target). 
 - On fbolt, logged out. Saw that I was redirected to the index and logged out. 
 -

#### Link to the relevant Github Issue

#6413
----

#### Does anything need to be done _before or after_ deploying this?
_before_ deploying this, we need to deploy https://github.com/inventables/fbolt/pull/6369/files


#### Who needs to be notified about these changes?
