### PR TITLE
Register customer privacy signals independently of the cookie banner

### DIFF
--- a/sections/cookie_banner.liquid
+++ b/sections/cookie_banner.liquid
@@ -21,20 +21,26 @@
       return document.cookie.split(';').some(crumb => crumb.trim().startsWith('_inv_read_cookie_policy_at='));
     };
 
-    const setShopifyTrackingConsent = () => {
+    const registerShopifyTrackingConsent = () => {
       window.Shopify.loadFeatures(
         [{ name: 'consent-tracking-api', version: '0.1' }],
         error => {
           if (error) { /* noop */ }
 
-          window.Shopify.customerPrivacy.setTrackingConsent({
-            'analytics': true,
-            'marketing': true,
-            'preferences': true
-          }, () => { /* success */ });
+          const { marketing, analytics, preferences } = window.Shopify.customerPrivacy.currentVisitorConsent();
+
+          if ([marketing, analytics, preferences].some(signal => signal === '')) {
+            window.Shopify.customerPrivacy.setTrackingConsent({
+              'analytics': true,
+              'marketing': true,
+              'preferences': true
+            }, () => { /* success */ });
+          }
         }
       );
     };
+
+    registerShopifyTrackingConsent();
 
     cookieBannerOk.addEventListener('click', () => {
       cookieBanner.style.display = 'none';
@@ -42,7 +48,6 @@
 
     if (!didReadCookiePolicy()) {
       setReadCookiePolicy();
-      setShopifyTrackingConsent();
       cookieBanner.style.display = 'block';
     }
 


### PR DESCRIPTION
**What does this PR do?**

This change allows for the customerPrivacy API to be called even if a visitor has already seen the cookie banner on a different Inventables property For example:

- Visitor visits easel.inventables.com
- Visitor sees the banner and the _inv_read_cookie_policy_at cookie is set
- Visitor visits inventables.com
- _inv_read_cookie_policy_at is already set, so the banner is not shown
- The visitor's currentVisitorConsent had not been set, so we call setTrackingConsent to register those signals

**Background Context and Screenshots**

@rodovich pointed out that if a visitor starts on a different property (such as the Forum or Easel), they will have seen the cookie banner, so when they visit the Shopify store they will neither see the banner a second time, nor have their consent "signals" set:

https://github.com/inventables/ecomm-theme-dawn/assets/26750330/a663291f-92db-48f5-9302-780da5fae68e

With this change, setTrackingConsent runs independently of the cookie banner if any of the GDPR signals (marketing, analytics, preferences) have not been set.


https://github.com/inventables/ecomm-theme-dawn/assets/26750330/1f1d57fc-e897-4d70-8704-f4ed0adecac8

**What steps did you take to test your changes?**

Tested this locally while previewing changes on the production store using `shopify theme serve`.

**Link to the relevant Github Issue**

Fix for an issue related to the cookie banner 