### PR TITLE
Remove express checkout buttons from cart page

### DIFF
--- a/sections/main-cart-footer.liquid
+++ b/sections/main-cart-footer.liquid
@@ -63,12 +63,6 @@
                   {{ 'sections.cart.checkout' | t }}
                 </button>
               </div>
-
-              {%- if additional_checkout_buttons -%}
-                <div class="cart__dynamic-checkout-buttons additional-checkout-buttons">
-                  {{ content_for_additional_checkout_buttons }}
-                </div>
-              {%- endif -%}
           {%- endcase -%}
         {% endfor %}
 


### PR DESCRIPTION
This PR removes the express checkout options from the cart page. 

Before: 
![image](https://github.com/inventables/ecomm-theme-dawn/assets/10675543/0f998eef-90cb-4dab-8ea0-a8182d074499)

After: 
![image](https://github.com/inventables/ecomm-theme-dawn/assets/10675543/7c019c2c-3b6a-411a-9a54-bbaa99618a9f)
