### PR TITLE
Fix propagation of cookie banner between pages

### DIFF
--- a/sections/cookie_banner.liquid
+++ b/sections/cookie_banner.liquid
@@ -14,7 +14,7 @@
     const cookieBannerOk = document.querySelector('.cookie-banner__btn--ok');
 
     const setReadCookiePolicy = () => {
-      document.cookie = `_inv_read_cookie_policy_at=${(new Date).getTime()}; Domain=inventables.com`;
+      document.cookie = `_inv_read_cookie_policy_at=${(new Date).getTime()}; domain=inventables.com; path=/; max-age=31536000`;
     };
 
     const didReadCookiePolicy = () => {


### PR DESCRIPTION
#### What does this PR do?

This applies the change from https://github.com/inventables/easel/pull/10069 to set the cookie banner cookie's `path` to allow it to be read from any paths on our domain—by default cookies are scoped to the beginning part of the path of the page where they're set (e.g. `/products` when set from a product page). Also sets `max-age` to 365 days so that the cookie outlasts the session.

#### Background Context and Screenshots

Depending on the initial landing page where the cookie banner cookie is set, the banner can appear again later. For example:

1. In a new browser or private/incognito tab, visit https://www.inventables.com/products/x-carve-1.
2. Notice the cookie banner.
3. Click "Add to cart".
4. The cart page shows the cookie banner again.

#### What steps did you take to test your changes?

I tested the same code changes in Easel using the dev tools, as described in https://github.com/inventables/easel/pull/10069.

**I have _not_ run through the same steps to test this change on the ecomm site.** The cookie banner implementations are very similar so I'm pretty confident it should work, but I'll leave it to ecomm folks to decide if it needs additional testing on this site.

#### Link to the relevant Github Issue


#### Checklist
- [ ] Followed [theme code principles](https://github.com/Shopify/dawn/blob/main/.github/CONTRIBUTING.md#theme-code-principles)
- [ ] Linted with [Theme Check](https://github.com/Shopify/theme-check)
- [ ] Tested on [mobile](https://shopify.dev/themes/store/requirements#mobile-browser-requirements)
- [ ] Tested on [multiple browsers](https://shopify.dev/themes/store/requirements#desktop-browser-requirements)
- [ ] Tested for [accessibility](https://shopify.dev/themes/best-practices/accessibility)


### Demo links

----

#### Does anything need to be done _before or after_ deploying this?

#### Who needs to be notified about these changes?
